### PR TITLE
change Chinese edition edit link

### DIFF
--- a/book.json
+++ b/book.json
@@ -28,7 +28,7 @@
             "url": "https://github.com/CloudNativeInfra/CNI"
         },
         "editlink": {
-            "base": "https://github.com/CloudNativeInfra/CNI/blob/master/",
+            "base": "https://github.com/CloudNativeInfra/CNI/blob/master/cn",
             "label": "Edit this page"
         },
         "github-buttons": {


### PR DESCRIPTION
The Gitbook plugin `editlink` can not support variable, since we have more than a language edition, I just only set the edit link to Chinese.